### PR TITLE
remove repo name from spec, use object name

### DIFF
--- a/apis/mpas/v1alpha1/repository_types.go
+++ b/apis/mpas/v1alpha1/repository_types.go
@@ -35,8 +35,6 @@ type RepositorySpec struct {
 	//+required
 	Owner string `json:"owner"`
 	//+required
-	RepositoryName string `json:"repositoryName"`
-	//+required
 	Credentials Credentials `json:"credentials"`
 
 	//+optional
@@ -101,10 +99,10 @@ func (in Repository) GetRequeueAfter() time.Duration {
 func (in Repository) GetRepositoryURL() string {
 	if in.Spec.Domain != "" {
 		if strings.Contains(in.Spec.Domain, "@") {
-			return fmt.Sprintf("%s:%s/%s", in.Spec.Domain, in.Spec.Owner, in.Spec.RepositoryName)
+			return fmt.Sprintf("%s:%s/%s", in.Spec.Domain, in.Spec.Owner, in.GetName())
 		}
 
-		return fmt.Sprintf("%s/%s/%s", in.Spec.Domain, in.Spec.Owner, in.Spec.RepositoryName)
+		return fmt.Sprintf("%s/%s/%s", in.Spec.Domain, in.Spec.Owner, in.GetName())
 	}
 
 	domain := ""
@@ -118,7 +116,7 @@ func (in Repository) GetRepositoryURL() string {
 		domain = "gitea.com"
 	}
 
-	return fmt.Sprintf("https://%s/%s/%s", domain, in.Spec.Owner, in.Spec.RepositoryName)
+	return fmt.Sprintf("https://%s/%s/%s", domain, in.Spec.Owner, in.GetName())
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/mpas.ocm.software_repositories.yaml
+++ b/config/crd/bases/mpas.ocm.software_repositories.yaml
@@ -93,8 +93,6 @@ spec:
                 type: string
               provider:
                 type: string
-              repositoryName:
-                type: string
               visibility:
                 default: private
                 enum:
@@ -107,7 +105,6 @@ spec:
             - isOrganization
             - owner
             - provider
-            - repositoryName
             type: object
           status:
             description: RepositoryStatus defines the observed state of Repository

--- a/controllers/delivery/sync_controller_test.go
+++ b/controllers/delivery/sync_controller_test.go
@@ -44,9 +44,8 @@ func TestSyncReconciler(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: mpasv1alpha1.RepositorySpec{
-			Provider:       "github",
-			Owner:          "Skarlso",
-			RepositoryName: "test",
+			Provider: "github",
+			Owner:    "Skarlso",
 			Credentials: mpasv1alpha1.Credentials{
 				SecretRef: v1.LocalObjectReference{
 					Name: secret.Name,
@@ -178,9 +177,8 @@ func TestSyncReconcilerWithAutomaticPullRequest(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: mpasv1alpha1.RepositorySpec{
-			Provider:       "github",
-			Owner:          "Skarlso",
-			RepositoryName: "test",
+			Provider: "github",
+			Owner:    "Skarlso",
 			Credentials: mpasv1alpha1.Credentials{
 				SecretRef: v1.LocalObjectReference{
 					Name: secret.Name,

--- a/controllers/mpas/suite_test.go
+++ b/controllers/mpas/suite_test.go
@@ -58,9 +58,8 @@ var (
 			Namespace: "default",
 		},
 		Spec: mpasv1alpha1.RepositorySpec{
-			Provider:       "github",
-			Owner:          "e2e-tester",
-			RepositoryName: "test-repository",
+			Provider: "github",
+			Owner:    "e2e-tester",
 			Credentials: mpasv1alpha1.Credentials{
 				SecretRef: corev1.LocalObjectReference{
 					Name: "repository-creds",

--- a/pkg/providers/gitea/gitea.go
+++ b/pkg/providers/gitea/gitea.go
@@ -81,7 +81,7 @@ func (c *Client) CreateRepository(ctx context.Context, obj mpasv1alpha1.Reposito
 	}
 
 	if _, _, err := client.CreateRepo(gitea.CreateRepoOption{
-		Name:          obj.Spec.RepositoryName,
+		Name:          obj.GetName(),
 		Description:   "Created by git-controller",
 		Private:       private,
 		AutoInit:      true,
@@ -127,7 +127,7 @@ func (f *fileCommitter) commitFile(client *gitea.Client, obj mpasv1alpha1.Reposi
 		return
 	}
 
-	_, _, err := client.CreateFile(obj.Spec.Owner, obj.Spec.RepositoryName, path, gitea.CreateFileOptions{
+	_, _, err := client.CreateFile(obj.Spec.Owner, obj.GetName(), path, gitea.CreateFileOptions{
 		FileOptions: gitea.FileOptions{
 			Message:    fmt.Sprintf("Adding '%s' file.", path),
 			BranchName: obj.Spec.DefaultBranch,
@@ -135,7 +135,7 @@ func (f *fileCommitter) commitFile(client *gitea.Client, obj mpasv1alpha1.Reposi
 		Content: content,
 	})
 	if err != nil {
-		if _, derr := client.DeleteRepo(obj.Spec.Owner, obj.Spec.RepositoryName); derr != nil {
+		if _, derr := client.DeleteRepo(obj.Spec.Owner, obj.GetName()); derr != nil {
 			err = errors.Join(err, derr)
 		}
 
@@ -193,7 +193,7 @@ func (c *Client) CreatePullRequest(ctx context.Context, branch string, sync deli
 		description = sync.Spec.PullRequestTemplate.Description
 	}
 
-	if _, _, err := client.CreatePullRequest(repository.Spec.Owner, repository.Spec.RepositoryName, gitea.CreatePullRequestOption{
+	if _, _, err := client.CreatePullRequest(repository.Spec.Owner, repository.GetName(), gitea.CreatePullRequestOption{
 		Head:  branch,
 		Base:  base,
 		Title: title,

--- a/pkg/providers/github/github.go
+++ b/pkg/providers/github/github.go
@@ -67,10 +67,10 @@ func (c *Client) CreateRepository(ctx context.Context, obj mpasv1alpha1.Reposito
 	}
 
 	if obj.Spec.IsOrganization {
-		return gogit.CreateOrganizationRepository(ctx, gc, domain, obj.Spec)
+		return gogit.CreateOrganizationRepository(ctx, gc, domain, obj)
 	}
 
-	return gogit.CreateUserRepository(ctx, gc, domain, obj.Spec)
+	return gogit.CreateUserRepository(ctx, gc, domain, obj)
 }
 
 // constructAuthenticationOption will take the object and construct an authentication option.
@@ -117,8 +117,8 @@ func (c *Client) CreatePullRequest(ctx context.Context, branch string, sync deli
 	}
 
 	if repository.Spec.IsOrganization {
-		return gogit.CreateOrganizationPullRequest(ctx, gc, domain, branch, sync.Spec.PullRequestTemplate, repository.Spec)
+		return gogit.CreateOrganizationPullRequest(ctx, gc, domain, branch, sync.Spec.PullRequestTemplate, repository)
 	}
 
-	return gogit.CreateUserPullRequest(ctx, gc, domain, branch, sync.Spec.PullRequestTemplate, repository.Spec)
+	return gogit.CreateUserPullRequest(ctx, gc, domain, branch, sync.Spec.PullRequestTemplate, repository)
 }

--- a/pkg/providers/gitlab/gitlab.go
+++ b/pkg/providers/gitlab/gitlab.go
@@ -80,10 +80,10 @@ func (c *Client) CreateRepository(ctx context.Context, obj mpasv1alpha1.Reposito
 	}
 
 	if obj.Spec.IsOrganization {
-		return gogit.CreateOrganizationRepository(ctx, gc, domain, obj.Spec)
+		return gogit.CreateOrganizationRepository(ctx, gc, domain, obj)
 	}
 
-	return gogit.CreateUserRepository(ctx, gc, domain, obj.Spec)
+	return gogit.CreateUserRepository(ctx, gc, domain, obj)
 }
 
 func (c *Client) CreatePullRequest(ctx context.Context, branch string, sync deliveryv1alpha1.Sync, repository mpasv1alpha1.Repository) error {
@@ -119,8 +119,8 @@ func (c *Client) CreatePullRequest(ctx context.Context, branch string, sync deli
 	}
 
 	if repository.Spec.IsOrganization {
-		return gogit.CreateOrganizationPullRequest(ctx, gc, domain, branch, sync.Spec.PullRequestTemplate, repository.Spec)
+		return gogit.CreateOrganizationPullRequest(ctx, gc, domain, branch, sync.Spec.PullRequestTemplate, repository)
 	}
 
-	return gogit.CreateUserPullRequest(ctx, gc, domain, branch, sync.Spec.PullRequestTemplate, repository.Spec)
+	return gogit.CreateUserPullRequest(ctx, gc, domain, branch, sync.Spec.PullRequestTemplate, repository)
 }


### PR DESCRIPTION
We made the decision to remove the `RepositoryName` field from the spec. Instead the repo name will be based on the name of the object. In the case of the mpas-project-controller this will be `<prefix(default=mpas)>-<project_name>`