### PR TITLE
resolve secret mismatch between repository and flux expectations

### DIFF
--- a/pkg/providers/gitea/gitea.go
+++ b/pkg/providers/gitea/gitea.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	tokenKey      = "token"
+	tokenKey      = "password"
 	providerType  = "gitea"
 	defaultDomain = "gitea.com"
 )

--- a/pkg/providers/github/github.go
+++ b/pkg/providers/github/github.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	tokenKey      = "token"
+	tokenKey      = "password"
 	providerType  = "github"
 	defaultDomain = github.DefaultDomain
 )

--- a/pkg/providers/gitlab/gitlab.go
+++ b/pkg/providers/gitlab/gitlab.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	tokenKey      = "token"
+	tokenKey      = "password"
 	providerType  = "gitlab"
 	defaultDomain = gitlab.DefaultDomain
 )


### PR DESCRIPTION
At the moment the secret that is expected to exist needs to contain `username` and `token` as the data keys, whereas Flux expects `username` and `password`: https://fluxcd.io/flux/components/source/gitrepositories/#basic-access-authentication.

This PR should bring them into alignment for basic auth.